### PR TITLE
"Flavor" text and food&drink consistency pass

### DIFF
--- a/STALKER 12/code/game/stalker/objects/items/food/drinks.dm
+++ b/STALKER 12/code/game/stalker/objects/items/food/drinks.dm
@@ -1,11 +1,12 @@
 /obj/item/weapon/reagent_containers/food/drinks/bottle/vodka/kazaki
 	name = "Vodka Kazaki"
-	desc = "Vodka by ukrainian company GSC. Smooth in flavour and burn. Some Stalkers swear by it's ability to purify the body of radiation"
+	desc = "Tasty mineral-water sourced from springs! If it hasn't been refilled with radioactive shitwater by some tourists."
 	eng_desc = "Vodka by ukrainian company GSC. Smooth in flavour and burn. Some Stalkers swear by it's ability to purify the body of radiation."
 	icon = 'icons/stalker/food.dmi'
 	icon_state = "gsc_vodka"
 	list_reagents = list("vodka" = 85, "potass_iodide" = 15)
 	w_class = 2
+	taste_description = "the classic flavor of high alcohol content grain liquor and all the burning that goes with it"
 
 /obj/item/weapon/reagent_containers/food/drinks/soda_cans/energetic
 	name = "S.T.A.L.K.E.R. Energy drink"
@@ -14,12 +15,14 @@
 	icon_state = "nonstop"
 	list_reagents = list("energetic" = 10, "water" = 20)
 	w_class = 2
+	taste_description = "sugar and chemicals with the vaguest fruit taste you can imagine"
 
 /obj/item/weapon/reagent_containers/food/drinks/soda_cans/voda
 	name = "Bottle"
-	desc = "Tasty mineral-water sourced from springs! If it hasn't been refilled with radioactive shitwater by some tourist.."
-	eng_desc = "Tasty mineral-water sourced from springs! If it hasn't been refilled with radioactive shitwater by some tourist.."
+	desc = "Tasty mineral-water sourced from springs! If it hasn't been refilled with radioactive shitwater by some tourists."
+	eng_desc = "Tasty mineral-water sourced from springs! If it hasn't been refilled with radioactive shitwater by some tourists."
 	icon = 'icons/stalker/food.dmi'
 	icon_state = "voda"
 	list_reagents = list("energetic" = 3, "water" = 37)
 	w_class = 2
+	taste_description = "regular-old water. Hopefully it isn't irradiated"

--- a/STALKER 12/code/game/stalker/objects/items/food/food.dm
+++ b/STALKER 12/code/game/stalker/objects/items/food/food.dm
@@ -12,7 +12,8 @@
 	trash = /obj/item/trash/konserva
 	list_reagents = list("nutriment" = 13, "vitamin" = 2, "omnizine" = 0.5)
 	var/icon_state_opened = "konserva_open"
-	var/desc_opened = "Tourist's delight, also known as tourist breakfast: is a staple food of The Zone. Legend says these cans of conserva are from a raid against an army warehouse! This ones open."
+	var/desc_opened = "Tourist's delight, also known as tourist breakfast is a staple food of The Zone. Legend says these cans of konserva are from a raid against an army warehouse! This one is opened."
+	taste_description = "almost unedibly salty meat"
 
 /obj/item/weapon/reagent_containers/food/snacks/stalker/konserva/attack_self(mob/user)
 	if(wrapped)
@@ -47,7 +48,9 @@
 	icon_state_opened = "shproti1"
 	list_reagents = list("nutriment" = 17, "vitamin" = 3, "omnizine" = 0.75)
 	trash = /obj/item/trash/konserva/shproti
-	desc_opened = "European sprats originating from the Latvian portcity of Riga. They've been preserved in a thick sunflower oil. This one is opened!"
+	desc_opened = "European sprats originating from the Latvian port-city of Riga. They've been preserved in a thick sunflower oil. This one is opened."
+	taste_description = "oily, salted fish"
+
 
 /obj/item/trash/konserva/shproti
 	name = "empty can"
@@ -66,7 +69,8 @@
 	icon_state_opened = "soup1"
 	list_reagents = list("nutriment" = 20, "vitamin" = 4, "omnizine" = 1)
 	trash = /obj/item/trash/konserva/soup
-	desc_opened = "Condensed soup that usually would be thinned with water. A staple of tourists within the zone. This ones opened."
+	desc_opened = "Condensed soup that usually would be thinned with water. A staple of tourists within the zone. This one is opened."
+	taste_description = "dry beets and sausage"
 
 /obj/item/trash/konserva/soup
 	name = "empty can"
@@ -82,7 +86,7 @@
 	icon_state_opened = "bobi1"
 	list_reagents = list("nutriment" = 17, "vitamin" = 3, "omnizine" = 0.75)
 	trash = /obj/item/trash/konserva/bobi
-	desc_opened = "A can of 'Bean Surprise'. A melody of cheap flavourless nibbles of meat and watery beans. This one is opened."
+	taste_description = "a vague earthy flavor with tasteless meat"
 
 /obj/item/trash/konserva/bobi
 	name = "empty can"
@@ -100,6 +104,7 @@
 	list_reagents = list("nutriment" = 20, "vitamin" = 4, "omnizine" = 1)
 	trash = /obj/item/trash/konserva/govyadina
 	desc_opened = "A can of beef-stew! An avidly loved staple of those who scour around old ruins in search for loot! This one is opened."
+	taste_description = "flavorful gravy over meat and potatoes"
 
 /obj/item/trash/konserva/govyadina
 	name = "empty can"
@@ -108,14 +113,15 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/stalker/konserva/fish
 	name = "fish"
-	desc = "Canned Fish. Simple, easy to digest and generally well-liked by most in the Zone."
-	eng_desc = "Canned Fish. Simple, easy to digest and generally well-liked by most in the Zone."
+	desc = "Canned fish. Simple, easy to digest and generally well-liked by most in the Zone."
+	eng_desc = "Canned fish. Simple, easy to digest and generally well-liked by most in the Zone."
 	icon = 'icons/stalker/food.dmi'
 	icon_state = "fish0"
 	icon_state_opened = "fish1"
 	list_reagents = list("nutriment" = 17, "vitamin" = 3, "omnizine" = 0.75)
 	trash = /obj/item/trash/konserva/fish
-	desc_opened = "Canned Fish. Simple, easy to digest and generally well-liked by most in the Zone. This one is opened."
+	desc_opened = "Canned fish. Simple, easy to digest and generally well-liked by most in the Zone. This one is opened."
+	taste_description = "fish. Old fish"
 
 /obj/item/trash/konserva/fish
 	name = "empty can"
@@ -132,7 +138,9 @@
 	icon_state_opened = "sirok1"
 	list_reagents = list("nutriment" = 11, "vitamin" = 1, "omnizine" = 0.3)
 	trash = /obj/item/trash/konserva/sirok
-	desc_opened = "A can of creamed cheese commonly seen in UAF mountaineer rations. This is opened."
+	desc_opened = "A can of creamed cheese commonly seen in UAF mountaineer rations. This one is opened."
+	taste_description = "sweetened curd with a vanilla kick"
+
 
 /obj/item/trash/konserva/sirok
 	name = "trash"
@@ -150,7 +158,8 @@
 	icon_state_opened = "snikers1"
 	list_reagents = list("nutriment" = 8, "sugar" = 6, "omnizine" = 0.2)
 	trash = /obj/item/trash/konserva/snikers
-	desc_opened = "Snickers. A reminder of home for western-tourists, a oddly sweet snack for locals. This ones opened."
+	desc_opened = "Snickers. A reminder of home for western-tourists, a oddly sweet snack for locals. This one is opened."
+	taste_description = "rich chocolate and peanut-butter with nuts"
 
 /obj/item/trash/konserva/snikers
 	name = "trash"
@@ -169,6 +178,7 @@
 	list_reagents = list("nutriment" = 9, "sugar" = 1, "omnizine" = 0.1, "energetic" = 5)
 	trash = /obj/item/trash/konserva/chocolate
 	desc_opened = "A bar of chocolate. A reminder of home in this harsh place. This one is opened."
+	taste_description = "artisinal chocolate. It isn't as sweet as processed chocolate, but still very good"
 
 /obj/item/trash/konserva/chocolate
 	name = "trash"
@@ -223,6 +233,7 @@
 	icon_state_opened = "GAL2"
 	list_reagents = list("nutriment" = 10, "omnizine" = 0.1)
 	trash = /obj/item/trash/konserva/galets
+	taste_description = "dry, stale crackers. Better than starving"
 
 /obj/item/trash/konserva/galets
 	name = "trash"
@@ -232,11 +243,12 @@
 	name = "Kasha"
 	desc = "Vacuum-sealed can of boiled buckwheat porridge. Isn't this traditionally baked?"
 	eng_desc = "Vacuum-sealed can of boiled buckwheat porridge. Isn't this traditionally baked?"
-	desc_opened = "Vacuum-sealed can of boiled buckwheat porridge. Isn't this traditionally baked? This one is opened.."
+	desc_opened = "Vacuum-sealed can of boiled buckwheat porridge. Isn't this traditionally baked? This one is opened."
 	icon_state = "Kasha1"
 	icon_state_opened = "Kasha2"
 	list_reagents = list("nutriment" = 15, "omnizine" = 0.2)
 	trash = /obj/item/trash/konserva/kasha
+	taste_description = "a strong, nutty flavor of buckwheat"
 
 /obj/item/trash/konserva/kasha
 	name = "trash"
@@ -251,6 +263,7 @@
 	icon_state_opened = "TushenkaRed2"
 	list_reagents = list("nutriment" = 17, "omnizine" = 0.2)
 	trash = /obj/item/trash/konserva/MREkonserva1
+	taste_description = "spiced meat and salt"
 
 /obj/item/trash/konserva/MREkonserva1
 	name = "trash"
@@ -265,6 +278,7 @@
 	icon_state_opened = "TushenkaGreen2"
 	list_reagents = list("nutriment" = 17, "omnizine" = 0.2)
 	trash = /obj/item/trash/konserva/MREkonserva2
+	taste_description = "poultry and various vegatables"
 
 /obj/item/trash/konserva/MREkonserva2
 	name = "trash"
@@ -279,6 +293,7 @@
 	icon_state_opened = "TushenkaBlue2"
 	list_reagents = list("nutriment" = 17, "omnizine" = 0.2, "vitamin" = 10)
 	trash = /obj/item/trash/konserva/MREkonserva3
+	taste_description = "a wide variety of vegatables"
 
 /obj/item/trash/konserva/MREkonserva3
 	name = "trash"
@@ -292,6 +307,7 @@
 	icon_state = "kolbasa"
 	w_class = 2
 	list_reagents = list("nutriment" = 11, "vitamin" = 1, "omnizine" = 0.3)
+	taste_description = "a distinct cardamom kick over a classic ukrainian sausage"
 
 /obj/item/weapon/reagent_containers/food/snacks/stalker/baton
 	name = "baton"
@@ -301,3 +317,4 @@
 	icon_state = "baton_stalker"
 	w_class = 2
 	list_reagents = list("nutriment" = 8, "omnizine" = 0.2)
+	taste_description = "dry but pleasant bread"

--- a/STALKER 12/code/modules/food&drinks/drinks/drinks.dm
+++ b/STALKER 12/code/modules/food&drinks/drinks/drinks.dm
@@ -11,6 +11,7 @@
 	possible_transfer_amounts = list(5,10,15,20,25,30,50)
 	volume = 50
 	burn_state = FIRE_PROOF
+	var/taste_description
 
 /obj/item/weapon/reagent_containers/food/drinks/New()
 	..()
@@ -32,7 +33,8 @@
 
 	if(M == user)
 		M << "<span class='notice'>You swallow a gulp of [src].</span>"
-
+		if(taste_description && reagents.total_volume)
+			M << "<span class='notice'>You can taste [taste_description].</span>"
 	else
 		M.visible_message("<span class='danger'>[user] attempts to feed the contents of [src] to [M].</span>", "<span class='userdanger'>[user] attempts to feed the contents of [src] to [M].</span>")
 		if(!do_mob(user, M))

--- a/STALKER 12/code/modules/food&drinks/food/snacks.dm
+++ b/STALKER 12/code/modules/food&drinks/food/snacks.dm
@@ -19,7 +19,7 @@
 	var/junkiness = 0  //for junk food. used to lower human satiety.
 	var/list/bonus_reagents = list() //the amount of reagents (usually nutriment and vitamin) added to crafted/cooked snacks, on top of the ingredients reagents.
 	var/customfoodfilling = 1 // whether it can be used as filling in custom food
-
+	var/taste_description //How does it taste?
 	//Placeholder for effect that trigger on eating that aren't tied to reagents.
 /obj/item/weapon/reagent_containers/food/snacks/proc/On_Consume()
 	if(!usr)	return
@@ -64,7 +64,7 @@
 				M << "<span class='notice'>You don't feel like eating any more junk food at the moment.</span>"
 				return 0
 			if(taste_description)
-				M << "<span class='notice'You can taste [taste_description].</span>
+				M << "<span class='notice'>You can taste [taste_description].</span>"
 			if(wrapped)
 				M << "<span class='warning'>You should unwrap [src] first!</span>"
 				return 0

--- a/STALKER 12/code/modules/food&drinks/food/snacks.dm
+++ b/STALKER 12/code/modules/food&drinks/food/snacks.dm
@@ -63,7 +63,8 @@
 			if(junkiness && M.satiety < -150 && M.nutrition > NUTRITION_LEVEL_STARVING + 50 )
 				M << "<span class='notice'>You don't feel like eating any more junk food at the moment.</span>"
 				return 0
-
+			if(taste_description)
+				M << "<span class='notice'You can taste [taste_description].</span>
 			if(wrapped)
 				M << "<span class='warning'>You should unwrap [src] first!</span>"
 				return 0


### PR DESCRIPTION
Food and drink items will append their taste to chat when specified

![image](https://user-images.githubusercontent.com/65516417/135176790-5400665c-0af5-428b-8fdc-52e75ffd5220.png)
Image provided is a slightly outdated version: flavor should always appear AFTER the eat text
Existing descriptions are placeholder